### PR TITLE
⚡ Optimize Broadcast track lookups

### DIFF
--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/msf/broadcast.go
+++ b/msf/broadcast.go
@@ -29,12 +29,20 @@ type Broadcast struct {
 	catalogTrackName moqt.TrackName
 	catalog          Catalog
 	tracks           moqt.Broadcast
+
+	trackIndexes map[string]int
 }
 
 // initLocked initializes lazily allocated broadcast defaults while b.mu is held.
 func (b *Broadcast) initLocked() {
 	if b.catalogTrackName == "" {
 		b.catalogTrackName = DefaultCatalogTrackName
+	}
+	if b.trackIndexes == nil {
+		b.trackIndexes = make(map[string]int)
+		for i, track := range b.catalog.Tracks {
+			b.trackIndexes[track.Name] = i
+		}
 	}
 }
 
@@ -109,6 +117,12 @@ func (b *Broadcast) SetCatalog(catalog Catalog) error {
 	b.initLocked()
 	staleTrackNames := b.staleTrackNamesLocked(clone)
 	b.catalog = clone
+
+	b.trackIndexes = make(map[string]int, len(b.catalog.Tracks))
+	for i, track := range b.catalog.Tracks {
+		b.trackIndexes[track.Name] = i
+	}
+
 	for _, name := range staleTrackNames {
 		b.tracks.Remove(name)
 	}
@@ -143,20 +157,16 @@ func (b *Broadcast) RegisterTrack(track Track, handler moqt.TrackHandler) error 
 	updated := b.catalog.Clone()
 	trackID := trackClone.ID(updated.DefaultNamespace)
 
-	replaced := false
-	for i := range updated.Tracks {
-		if updated.Tracks[i].Name == trackClone.Name {
-			if updated.Tracks[i].ID(updated.DefaultNamespace) != trackID {
-				return fmt.Errorf("msf: broadcast requires unique track names across namespaces; duplicate name %q found for %q and %q", trackClone.Name, updated.Tracks[i].ID(updated.DefaultNamespace).String(), trackID.String())
-			}
-			updated.Tracks[i] = trackClone
-			replaced = true
-			break
+	idx, replaced := b.trackIndexes[trackClone.Name]
+	if replaced {
+		if updated.Tracks[idx].ID(updated.DefaultNamespace) != trackID {
+			return fmt.Errorf("msf: broadcast requires unique track names across namespaces; duplicate name %q found for %q and %q", trackClone.Name, updated.Tracks[idx].ID(updated.DefaultNamespace).String(), trackID.String())
 		}
-	}
-	if !replaced {
+		updated.Tracks[idx] = trackClone
+	} else {
 		updated.Tracks = append(updated.Tracks, trackClone)
 	}
+
 	if err := updated.Validate(); err != nil {
 		return err
 	}
@@ -165,6 +175,9 @@ func (b *Broadcast) RegisterTrack(track Track, handler moqt.TrackHandler) error 
 	}
 
 	b.catalog = updated
+	if !replaced {
+		b.trackIndexes[trackClone.Name] = len(updated.Tracks) - 1
+	}
 	return b.tracks.Register(moqt.TrackName(trackClone.Name), handler)
 }
 
@@ -182,15 +195,18 @@ func (b *Broadcast) RemoveTrack(name moqt.TrackName) bool {
 	b.initLocked()
 	updated := b.catalog.Clone()
 	removed := false
-	for i := range updated.Tracks {
-		if moqt.TrackName(updated.Tracks[i].Name) == name {
-			updated.Tracks = append(updated.Tracks[:i], updated.Tracks[i+1:]...)
-			removed = true
-			break
+
+	nameStr := string(name)
+	if idx, ok := b.trackIndexes[nameStr]; ok {
+		updated.Tracks = append(updated.Tracks[:idx], updated.Tracks[idx+1:]...)
+		removed = true
+		b.catalog = updated
+
+		delete(b.trackIndexes, nameStr)
+		for i := idx; i < len(updated.Tracks); i++ {
+			b.trackIndexes[updated.Tracks[i].Name] = i
 		}
 	}
-
-	b.catalog = updated
 	removedFromTracks := b.tracks.Remove(name)
 
 	return removed || removedFromTracks

--- a/msf/broadcast_benchmark_test.go
+++ b/msf/broadcast_benchmark_test.go
@@ -1,0 +1,58 @@
+package msf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+)
+
+func BenchmarkBroadcastRegisterTrack(b *testing.B) {
+	b.ReportAllocs()
+
+	handler := moqt.TrackHandlerFunc(func(tw *moqt.TrackWriter) {})
+
+	for _, size := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("N=%d", size), func(b *testing.B) {
+			broadcast, err := NewBroadcast(Catalog{Version: 1})
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Pre-populate
+			for i := 0; i < size; i++ {
+				err = broadcast.RegisterTrack(Track{
+					Name:      fmt.Sprintf("track-%d", i),
+					Namespace: "ns1",
+					Packaging: PackagingLOC,
+					IsLive:    new(false),
+				}, handler)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			newTrack := Track{
+				Name:      fmt.Sprintf("track-%d", size),
+				Namespace: "ns1",
+				Packaging: PackagingLOC,
+				IsLive:    new(false),
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Registering a new track will do a linear scan over 'size' elements
+				// then append.
+				err = broadcast.RegisterTrack(newTrack, handler)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				b.StopTimer()
+				// Remove to keep the size the same for the next iteration
+				broadcast.RemoveTrack(moqt.TrackName(newTrack.Name))
+				b.StartTimer()
+			}
+		})
+	}
+}


### PR DESCRIPTION
💡 **What:** Replaced O(N) linear search for tracks in `Broadcast.RegisterTrack` and `Broadcast.RemoveTrack` with an O(1) map lookup using an internal `trackIndexes` map.

🎯 **Why:** Registering or removing tracks previously required a linear scan over all tracks in the catalog. As catalogs grow, this becomes a performance bottleneck.

📊 **Measured Improvement:**
- N=1000: 1425154 ns/op -> 1218363 ns/op
- N=100: 74846 ns/op -> 68125 ns/op
- N=10: 15010 ns/op -> 12357 ns/op

---
*PR created automatically by Jules for task [12681185805381651657](https://jules.google.com/task/12681185805381651657) started by @okdaichi*