### PR TITLE
⚡ Bolt: Optimize duplicate detection in Catalog.Validate

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## YYYY-MM-DD - Avoid Map Initialization Overhead for Small Lists
 **Learning:** For finding duplicates or validating uniqueness in very small slices (e.g., N <= 16), an O(N^2) nested loop comparison against a stack-allocated array is measurably faster than using a `map[T]struct{}`. Even if escape analysis optimizes the map to the stack, the nested loop avoids map initialization and element hashing overhead on the happy path.
 **Action:** Provide a fast-path fallback using a small, stack-allocated array and O(N^2) loop for uniqueness detection on small bounded items before falling back to a map.
+## YYYY-MM-DD - [Optimize inner duplicate validation loops]
+**Learning:** When replacing a map with an O(N^2) nested loop for duplicate detection in small Go slices, maintain a dedicated counter (e.g., `numSeen`) to track actual unique items added rather than using the outer loop index (`i`).
+**Action:** When skipping duplicates in array-based fallback checks, use a discrete counter for the inner loop bounds.

--- a/msf/catalog.go
+++ b/msf/catalog.go
@@ -264,10 +264,12 @@ func (c Catalog) Validate() error {
 	} else if len(c.Tracks) > 1 {
 		var seen [16]TrackID
 		seen[0] = c.Tracks[0].ID(c.DefaultNamespace)
+		// Bolt: keep a dedicated counter for unique items to prevent bounds mismatch when skipping duplicates
+		numSeen := 1
 		for i := 1; i < len(c.Tracks); i++ {
 			id := c.Tracks[i].ID(c.DefaultNamespace)
 			isDuplicate := false
-			for j := 0; j < i; j++ {
+			for j := 0; j < numSeen; j++ {
 				if seen[j] == id {
 					problems = append(problems, fmt.Sprintf("tracks[%d]: duplicate track identity %q", i, id.String()))
 					isDuplicate = true
@@ -275,7 +277,8 @@ func (c Catalog) Validate() error {
 				}
 			}
 			if !isDuplicate {
-				seen[i] = id
+				seen[numSeen] = id
+				numSeen++
 			}
 		}
 	}


### PR DESCRIPTION
💡 What: Optimized the inner loop for small catalog track duplication checks by fixing array bounds checking and replacing it with `numSeen` tracking.
🎯 Why: To avoid incorrect iteration bounds and zero-value matching when duplicate records are skipped. 
📊 Impact: Minor performance improvement and ensures logical correctness for the O(N^2) inner loop optimization for duplicate track checks when `N <= 16`.
🔬 Measurement: Code review to confirm bounds are strictly matching populated array indices.

---
*PR created automatically by Jules for task [14116358840075964273](https://jules.google.com/task/14116358840075964273) started by @okdaichi*