### PR TITLE
⚡ Bolt: Fix O(N^2) stack array loop bounds in duplicate detection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## YYYY-MM-DD - Avoid Map Initialization Overhead for Small Lists
 **Learning:** For finding duplicates or validating uniqueness in very small slices (e.g., N <= 16), an O(N^2) nested loop comparison against a stack-allocated array is measurably faster than using a `map[T]struct{}`. Even if escape analysis optimizes the map to the stack, the nested loop avoids map initialization and element hashing overhead on the happy path.
 **Action:** Provide a fast-path fallback using a small, stack-allocated array and O(N^2) loop for uniqueness detection on small bounded items before falling back to a map.
+## 2026-07-20 - Correct bounds tracking in array duplicate detection
+**Learning:** When optimizing duplicate detection using a fixed-size stack array and an O(N^2) loop, if duplicates are skipped, a dedicated counter (e.g., `numSeen`) must be used to track the actual number of unique items added to the array. Using the outer loop index (`i`) for the inner loop bounds will diverge from the true array length if duplicates exist, causing subsequent comparisons against zero-initialized elements or array bounds violations.
+**Action:** Always maintain a separate counter variable for the actual length of a stack array being incrementally populated when elements can be skipped.

--- a/msf/broadcast.go
+++ b/msf/broadcast.go
@@ -326,13 +326,20 @@ func validateCatalogForBroadcast(catalog Catalog, catalogTrackName moqt.TrackNam
 				return fmt.Errorf("msf: catalog contains reserved track name %q", catalogTrackName)
 			}
 			id := track.ID(catalog.DefaultNamespace)
+			isDuplicate := false
 			for j := 0; j < numSeen; j++ {
-				if seen[j].name == name && seen[j].id != id {
-					return fmt.Errorf("msf: broadcast requires unique track names across namespaces; duplicate name %q found for %q and %q", name, seen[j].id.String(), id.String())
+				if seen[j].name == name {
+					if seen[j].id != id {
+						return fmt.Errorf("msf: broadcast requires unique track names across namespaces; duplicate name %q found for %q and %q", name, seen[j].id.String(), id.String())
+					}
+					isDuplicate = true
+					break
 				}
 			}
-			seen[numSeen] = seenEntry{name: name, id: id}
-			numSeen++
+			if !isDuplicate {
+				seen[numSeen] = seenEntry{name: name, id: id}
+				numSeen++
+			}
 		}
 	} else {
 		seen := make(map[moqt.TrackName]TrackID, len(catalog.Tracks))

--- a/msf/catalog.go
+++ b/msf/catalog.go
@@ -264,10 +264,11 @@ func (c Catalog) Validate() error {
 	} else if len(c.Tracks) > 1 {
 		var seen [16]TrackID
 		seen[0] = c.Tracks[0].ID(c.DefaultNamespace)
+		numSeen := 1
 		for i := 1; i < len(c.Tracks); i++ {
 			id := c.Tracks[i].ID(c.DefaultNamespace)
 			isDuplicate := false
-			for j := 0; j < i; j++ {
+			for j := 0; j < numSeen; j++ {
 				if seen[j] == id {
 					problems = append(problems, fmt.Sprintf("tracks[%d]: duplicate track identity %q", i, id.String()))
 					isDuplicate = true
@@ -275,7 +276,8 @@ func (c Catalog) Validate() error {
 				}
 			}
 			if !isDuplicate {
-				seen[i] = id
+				seen[numSeen] = id
+				numSeen++
 			}
 		}
 	}


### PR DESCRIPTION
💡 What: Fixed inner loop boundaries and index assignment in stack array duplicate detection for small catalogs (N<=16).
🎯 Why: Previously, the inner loop bounds used the outer loop index (which diverges when duplicates are skipped), or incorrectly assigned elements without tracking actual array length, leading to comparisons against zero-initialized elements or missed duplicate reporting.
📊 Impact: Correctness fix for an existing performance optimization. Prevents incorrect duplicate parsing for valid inputs.
🔬 Measurement: Verified with `go test ./...` and targeted manual benchmark analysis.

---
*PR created automatically by Jules for task [2378795980987658511](https://jules.google.com/task/2378795980987658511) started by @okdaichi*